### PR TITLE
Remove unused BeamNG parameter from LiDAR path

### DIFF
--- a/simulation/beamng.py
+++ b/simulation/beamng.py
@@ -727,7 +727,7 @@ def main():
             lidar_yaw = car_yaw  # LiDAR has same yaw as vehicle
 
             try:
-                lidar_lane_boundaries, filtered_points = lidar_process_frame(lidar, beamng=beamng, speed=speed_kph, debug_window=None, vehicle=vehicle, car_position=car_pos, car_direction=direction)
+                lidar_lane_boundaries, filtered_points = lidar_process_frame(lidar, speed=speed_kph, debug_window=None, vehicle=vehicle, car_position=car_pos, car_direction=direction)
             except Exception as lidar_e:
                 print(f"[LiDAR] Lidar process error: {lidar_e}")
                 lidar_lane_boundaries = None

--- a/src/sensor_fusion/lidar/lidar.py
+++ b/src/sensor_fusion/lidar/lidar.py
@@ -7,7 +7,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../.
 Utility function for collecting lidar point cloud data, to later be used for processing
 """
 
-def collect_lidar_data(beamng, lidar_data):
+def collect_lidar_data(lidar_data):
     
     if lidar_data is None:
         print("LiDAR data is None")

--- a/src/sensor_fusion/lidar/main.py
+++ b/src/sensor_fusion/lidar/main.py
@@ -1,18 +1,18 @@
-from src.sensor_fusion.lidar.lidar import collect_lidar_data
+from .lidar import collect_lidar_data
 import numpy as np
 
 from .preprocessing import LidarPreprocessor
 
 _preprocessor = LidarPreprocessor()
 
-def process_frame(lidar_sensor, beamng, speed, debug_window=None, vehicle=None, car_position=None, car_direction=None):
+def process_frame(lidar_sensor, speed, debug_window=None, vehicle=None, car_position=None, car_direction=None):
     try:
         lidar_data = lidar_sensor.poll()
         if lidar_data is None:
             print("[Lidar] Warning: LiDAR sensor returned None")
             return {}, []
 
-        point_cloud = collect_lidar_data(beamng, lidar_data)
+        point_cloud = collect_lidar_data(lidar_data)
         if len(point_cloud) == 0:
             print("[Lidar] Warning: Empty LiDAR point cloud")
             return {}, []


### PR DESCRIPTION
## Summary
- Removes the unused `beamng` argument from `collect_lidar_data` and `process_frame` in the LiDAR path
- Updates the BeamNG call site accordingly
- Switches the LiDAR import to a relative import (matches `carla-support`)
This is a small prerequisite for CARLA: the LiDAR module no longer requires a BeamNG object to call.